### PR TITLE
Draft initial use case in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The initial use case is in scientific computing, where:
 
 1. You want to use the the APIs you know and love (ex. NumPy).
 2. But you want it to execute in a new way (ex. on a GPU or distributed accross machines).
-3. And you want to optimize a chain of operations before executing (ex. `(x * y)[0]` -> `x[0] * y[0]`).
+3. And you want to optimize a chain of operations before executing (ex. `(x * y)[0]` -> `x[0] * y[0]` / [Mathematics of Arrays](https://paperpile.com/app/p/5de098dd-606d-0124-a25d-db5309f99394)).
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -2,30 +2,117 @@
 
 [![Documentation Status](https://readthedocs.org/projects/metadsl/badge/?version=latest)](https://metadsl.readthedocs.io/en/latest/?badge=latest)
 
-
 A framework for creating domain specific language libraries in Python.
 
-The end goal is for libraries like NumPy, Dask, Numba, and AutoGraph to be able to share
-optimizations and representations, as much as possible.
+The initial use case is in scientific computing, where:
 
-The MVP is a lazy version of the NumPy API that can execute normally, but creates
-an intermediate form that expresses the operations to perform, before performing them.
-
-## Why?
-
-1. You want to map Python to some other execution context.
-2. But you want users to be able to use their existing APIs they know and love.
-3. Also you want to build up some larger chunk of computation to dispatch, instead of executing every function.
-
-This project explores how to do that, in a way where we can share work and multiple DSLs can easily talk to one another.
+1. You want to use the the APIs you know and love (ex. NumPy).
+2. But you want it to execute in a new way (ex. on a GPU or distributed accross machines).
+3. And you want to optimize a chain of operations before executing (ex. `(x * y)[0]` -> `x[0] * y[0]`).
 
 
-## Roadmap
+## Example
+*This is not implemented yet but is the desired API.*
 
-- [ ] Get NP select example working, with codegen
-    - [ ] Figure out Pure/compat type story. 
-    - [ ] Copy over similar replacement based system so we can reuse existing uarray work
-    - [ ] Copy over previous uarray work, update to work with new functions
+### 1. NumPy API
+
+First build up an expression, using the NumPy compatible API:
+
+```python
+import metadsl.numpy.compat as np
+
+x = np.arange(10)
+condlist = [x<3, x>5]
+choicelist = [x, x**2]
+y = np.multiply.outer(np.select(condlist, choicelist), x)
+```
+
+### 2. Execute Torch / Tensorflow
+
+Then you can execute it, using torch, optionally printing out the generated sources:
+
+```python
+import metadsl.torch
+
+metadsl.torch.execute_numpy(y, print_source=True)
+```
+
+Which prints:
+
+```python
+import torch
+
+def fn(): 
+    x = torch.arange(10)
+    selected = torch.where(x < 3, x, torch.where(x > 5, x ** 2, torch.zeros_like(x)))
+    return torch.tensordot(selected, x, dims=0)
+```
+
+You can also execute it with TensorFlow:
+
+
+```python
+import metadsl.tensorflow
+
+metadsl.tensorflow.execute_numpy(y, print_source=True)
+```
+
+Which prints:
+
+```python
+import tensorflow
+
+@tensorflow.function
+def fn():
+    x = tf.range(10)
+    selected = tensorflow.where(x < 3, x, tensorflow.where(x > 5, x ** 2, tensorflow.zeros_like(x)))
+    return tensorflow.tensordot(selected, x, axes=0)
+```
+
+### 3. Optimize Operations
+
+Finally, you can also execute the operations in an optimized way,
+by combing all the operations into one loop, which can help performance in some case.
+
+You can do this for the original NumPy backend:
+
+```python
+import metadsl.numpy
+
+metadsl.torch.execute_numpy(y, print_source=True, optimize=True)
+```
+
+```python
+import numpy
+
+def fn():
+    x = numpy.empty((10,10))
+    
+    # Or this could produce one loop over all 100 items
+    # and calculate index manually and then resahpe
+    for i in range(10):
+        for j in range(10):
+            selected = i if i < 3 else (i ** 2 if i > 5 else 0)
+            x[i, j] = selected * j
+    return x
+```
+
+And we can do this for PyTorch and Tensorflow backends as well:
+
+TODO: Add these examples in the same style.
+
+
+## Guiding Principles
+
+The goal here is to share as much optimization and representation logic as possible, so that the world users
+exist in can be extended more easily without having to cause them to change their code.
+
+For example, if someone comes up with a new way of executing linear algebra or wants to try out a new way of optimizing
+expressions, they should be able to write those things in a pluggable manner, so that users can try them out with minimal
+effort. 
+
+This means we have to explicitly expose the protocols of the different levels to foster distributed collaboration and reuse. 
+
 
 ## Development
 
@@ -36,7 +123,7 @@ repo2docker -E .
 ```
 
 
-Or get started with conda:
+Or get started with Conda/flit:
 
 ```bash
 conda create -n metadsl jupyterlab

--- a/explorations/2019.04.06 TF Torch.ipynb
+++ b/explorations/2019.04.06 TF Torch.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PyTorch / TF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "       [  0,   1,   2,   3,   4,   5,   6,   7,   8,   9],\n",
+       "       [  0,   2,   4,   6,   8,  10,  12,  14,  16,  18],\n",
+       "       [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "       [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "       [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "       [  0,  36,  72, 108, 144, 180, 216, 252, 288, 324],\n",
+       "       [  0,  49,  98, 147, 196, 245, 294, 343, 392, 441],\n",
+       "       [  0,  64, 128, 192, 256, 320, 384, 448, 512, 576],\n",
+       "       [  0,  81, 162, 243, 324, 405, 486, 567, 648, 729]])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as real_np\n",
+    "\n",
+    "x = real_np.arange(10)\n",
+    "condlist = [x<3, x>5]\n",
+    "choicelist = [x, x**2]\n",
+    "selected = real_np.select(condlist, choicelist)\n",
+    "real_np.multiply.outer(selected, x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[  0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.],\n",
+       "       [  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.],\n",
+       "       [  0.,   2.,   4.,   6.,   8.,  10.,  12.,  14.,  16.,  18.],\n",
+       "       [  0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.],\n",
+       "       [  0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.],\n",
+       "       [  0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.,   0.],\n",
+       "       [  0.,  36.,  72., 108., 144., 180., 216., 252., 288., 324.],\n",
+       "       [  0.,  49.,  98., 147., 196., 245., 294., 343., 392., 441.],\n",
+       "       [  0.,  64., 128., 192., 256., 320., 384., 448., 512., 576.],\n",
+       "       [  0.,  81., 162., 243., 324., 405., 486., 567., 648., 729.]])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def fn():\n",
+    "    x = numpy.empty((10,10))\n",
+    "\n",
+    "    for i in range(10):\n",
+    "        for j in range(10):\n",
+    "            selected = i if i < 3 else (i ** 2 if i > 5 else 0)\n",
+    "            x[i, j] = selected * j\n",
+    "    return x\n",
+    "fn()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install torch torchvision"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "        [  0,   1,   2,   3,   4,   5,   6,   7,   8,   9],\n",
+       "        [  0,   2,   4,   6,   8,  10,  12,  14,  16,  18],\n",
+       "        [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "        [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "        [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "        [  0,  36,  72, 108, 144, 180, 216, 252, 288, 324],\n",
+       "        [  0,  49,  98, 147, 196, 245, 294, 343, 392, 441],\n",
+       "        [  0,  64, 128, 192, 256, 320, 384, 448, 512, 576],\n",
+       "        [  0,  81, 162, 243, 324, 405, 486, 567, 648, 729]])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "\n",
+    "x = torch.arange(10)\n",
+    "selected = torch.where(x < 3, x, torch.where(x > 5, x ** 2, torch.zeros_like(x)))\n",
+    "torch.tensordot(selected, x, dims=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install tensorflow==2.0.0-alpha0 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<tf.Tensor: id=29, shape=(10, 10), dtype=int32, numpy=\n",
+       "array([[  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "       [  0,   1,   2,   3,   4,   5,   6,   7,   8,   9],\n",
+       "       [  0,   2,   4,   6,   8,  10,  12,  14,  16,  18],\n",
+       "       [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "       [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "       [  0,   0,   0,   0,   0,   0,   0,   0,   0,   0],\n",
+       "       [  0,  36,  72, 108, 144, 180, 216, 252, 288, 324],\n",
+       "       [  0,  49,  98, 147, 196, 245, 294, 343, 392, 441],\n",
+       "       [  0,  64, 128, 192, 256, 320, 384, 448, 512, 576],\n",
+       "       [  0,  81, 162, 243, 324, 405, 486, 567, 648, 729]], dtype=int32)>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "@tf.function\n",
+    "def tf_fn():\n",
+    "    x = tf.range(10)\n",
+    "    selected = tf.where(x < 3, x, tf.where(x > 5, x ** 2, tf.zeros_like(x)))\n",
+    "    return tf.tensordot(selected, x, axes=0)\n",
+    "\n",
+    "tf_fn()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I have drafted initial use cases in the README and would appreciate any feedback / criticism. 

The approach I outline is the "Let's have a NumPy API that can compile to other backends" use case.

I was also considering the "Running existing SciPy code that depends on NumPy API on another backend" use case (this is what I presented about at tech share). But I have been thinking maybe this shouldn't be the initial use case, because it would be hard to satisfy parts of the NumPy API that SciPy depends on, like using Python control flow or it's memory layout (as @rgommers brought up (https://github.com/Quansight-Labs/metadsl/issues/42#issuecomment-480376952))


And it seems like having a NumPy compatible API that executes in other backends is being asked for in the community right now, see https://github.com/pytorch/pytorch/issues/2228, [@mrocklin's latest talk](https://docs.google.com/presentation/d/e/2PACX-1vQSu13Rg6DEcHbk3bNOa-7WV5Bi7gJMCI8_inAQMy6zV8DhPk0kzRSn0Y37MejM3m0qMuMCGpeaVXFK/pub?start=false&loop=false&delayms=60000&slide=id.g557e69ad01_0_55):

<img width="953" alt="Screen Shot 2019-04-06 at 3 31 20 PM" src="https://user-images.githubusercontent.com/1186124/55674311-18b43700-5881-11e9-91fb-3ac25b6146b5.png">


So the idea is we get people in the door with the library by allowing them to translate between different APIs, and they don't know/care about any internal graph representations or anything like that. But, because we are using these representations, we can slip in MoA optimizations in the middle, in a way that is not disruptive to their workflow.


I was also thinking about if an "eager" mode should be on the MVP roadmap or if users are OK with dealing with the, build up graph then execute approach. 
 